### PR TITLE
Update Dockerfile to correct miniconda and conda versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && apt-get install -y \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Setup CONDA (https://hub.docker.com/r/continuumio/miniconda3/~/dockerfile/)
-ENV MINICONDA_VERSION 3.16.0
-ENV CONDA_VERSION 3.19.0
+ENV MINICONDA_VERSION 4.1.11
+ENV CONDA_VERSION 4.1.11
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda-$MINICONDA_VERSION-Linux-x86_64.sh && \
     /bin/bash /Miniconda-$MINICONDA_VERSION-Linux-x86_64.sh -b -p /opt/conda && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 
 # Setup CONDA (https://hub.docker.com/r/continuumio/miniconda3/~/dockerfile/)
 ENV MINICONDA_VERSION 4.1.11
-ENV CONDA_VERSION 4.1.11
+ENV CONDA_VERSION 4.1.12
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda-$MINICONDA_VERSION-Linux-x86_64.sh && \
     /bin/bash /Miniconda-$MINICONDA_VERSION-Linux-x86_64.sh -b -p /opt/conda && \


### PR DESCRIPTION
Update Dockerfile to correct miniconda and conda versions: 4.1.11 for miniconda, 4.1.12 for conda
Hopefully this will fix the problem building the docker container. 
