### PR TITLE
update python, pycsw and baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest-amd64
+FROM phusion/baseimage:0.11
 CMD ["/sbin/my_init", "--quiet"]
 
 MAINTAINER Kyle Wilcox <kyle@axiomdatascience.com>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM phusion/baseimage:0.10.1
+FROM phusion/baseimage:latest-amd64
 CMD ["/sbin/my_init", "--quiet"]
 
 MAINTAINER Kyle Wilcox <kyle@axiomdatascience.com>
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
 
-ENV PYTHON_VERSION 3.6
+ENV PYTHON_VERSION 3.7
 ENV MINICONDA_VERSION latest
 
-ENV PYCSW_VERSION 2.2.0
+ENV PYCSW_VERSION 2.4.1
 ENV PYCSW_ROOT /opt/pycsw
 ENV PYCSW_STORE_ROOT /store
 ENV PYCSW_FORCE_ROOT /force
@@ -69,7 +69,7 @@ RUN curl -k -o ./miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${M
     ${CONDA_ROOT}/bin/conda install \
         python==${PYTHON_VERSION} \
         gunicorn \
-        "shapely<1.6" \
+        shapely \
         SQLAlchemy \
         psycopg2 \
         && \


### PR DESCRIPTION
@kwilcox, I'm not sure about whether `phusion/baseimage:latest-amd64` is the optimal base container layer, but at least this builds and runs the latest pycsw.  

I do get some warnings when running the various commands in the containers:
```
root@ee4b1a7e9f09:/etc/cron.d# pycsw_wipe
bin/pycsw-admin.py:225: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  SCP = configparser.SafeConfigParser()
bin/pycsw-admin.py:227: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  SCP.readfp(f)
Done
```
```
root@ee4b1a7e9f09:/etc/cron.d# pycsw_load
bin/pycsw-admin.py:225: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  SCP = configparser.SafeConfigParser()
bin/pycsw-admin.py:227: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  SCP.readfp(f)
/opt/conda/lib/python3.7/site-packages/owslib/iso.py:117: FutureWarning: the .identification and .serviceidentification properties will merge into .identification being a list of properties.  This is currently implemented in .identification info.  Please see https://github.com/geopython/OWSLib/issues/38 for more information
  FutureWarning)
/opt/conda/lib/python3.7/site-packages/owslib/iso.py:495: FutureWarning: The .keywords and .keywords2 properties will merge into the .keywords property in the future, with .keywords becoming a list of MD_Keywords instances. This is currently implemented in .keywords2. Please see https://github.com/geopython/OWSLib/issues/301 for more information
  FutureWarning)
```